### PR TITLE
feat: enable web history by default

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -7,8 +7,8 @@ import SettingsView from '@/views/SettingsView.vue';
 import BlockTransactions from '@/views/BlockTransactions.vue';
 
 const router = createRouter({
-  // history: createWebHistory(import.meta.env.BASE_URL),
-  history: createMemoryHistory(),
+  history: createWebHistory(import.meta.env.BASE_URL),
+  // history: createMemoryHistory(),
   routes: [
     {
       path: '/',

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
Had to add `vite-env.d.ts` after following some suggestion online
to fix a type error i was getting on `import.meta.env.BASE_URL`
even though the docs specifies its a built-in constant
https://vite.dev/guide/env-and-mode#built-in-constants :shrug:

Closes https://github.com/paulmillr/esplr/issues/15
